### PR TITLE
fix link errors and build warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,8 +8,6 @@ build:asan --linkopt -fsanitize=address
 # For all builds, use C++17
 build --cxxopt="-std=c++17"
 build --cxxopt='-Wno-sign-compare'
-build --linkopt=-ldl
-build --linkopt=-lrt
 
 # For Apple Silicon
 build:apple_silicon --cpu=darwin_arm64

--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,8 @@ build:asan --linkopt -fsanitize=address
 # For all builds, use C++17
 build --cxxopt="-std=c++17"
 build --cxxopt='-Wno-sign-compare'
+build --linkopt=-ldl
+build --linkopt=-lrt
 
 # For Apple Silicon
 build:apple_silicon --cpu=darwin_arm64

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -21,4 +21,10 @@ cc_library(
         "@coroutines//:co",
         "@toolbelt//toolbelt",
     ],
+    linkopts = select({
+        "//:macos_x86_64": [],
+        "//:macos_arm64": [],
+        "//:macos_default": [],
+        "//conditions:default": [ "-lrt" ],
+    }),
 )

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -204,7 +204,7 @@ Channel::Allocate(const toolbelt::FileDescriptor &scb_fd, int slot_size,
     return p.status();
   }
   ccb_ = reinterpret_cast<ChannelControlBlock *>(*p);
-  memset(ccb_, 0, ccb_size);
+  *ccb_ = ChannelControlBlock{};
 
   // Create a single buffer but don't map it in.  There is no need to
   // map in the buffers in the server since they will never be used.

--- a/common/channel.h
+++ b/common/channel.h
@@ -94,25 +94,25 @@ struct SystemControlBlock {
 // addresses in each client.  Instead they use an offset from the
 // start of the ChannelControlBlock (CCB) as a pointer.
 struct SlotListElement {
-  int32_t prev{};
-  int32_t next{};
+  int32_t prev = 0;
+  int32_t next = 0;
 };
 
 // Double linked list header in shared memory.
 struct SlotList {
-  int32_t first{};
-  int32_t last{};
+  int32_t first = 0;
+  int32_t last = 0;
 };
 
 // This is the meta data for a slot.  It is always in a linked list.
 struct MessageSlot {
   SlotListElement element{};
-  int32_t id{};                 // Unique ID for slot (0...num_slots-1).
-  int16_t ref_count{};          // Number of subscribers referring to this slot.
-  int16_t reliable_ref_count{}; // Number of reliable subscriber references.
-  int64_t ordinal{};            // Message ordinal held currently in slot.
-  int64_t message_size{};       // Size of message held in slot.
-  int32_t buffer_index{};       // Index of buffer.
+  int32_t id = 0;                 // Unique ID for slot (0...num_slots-1).
+  int16_t ref_count = 0;          // Number of subscribers referring to this slot.
+  int16_t reliable_ref_count = 0; // Number of reliable subscriber references.
+  int64_t ordinal = 0;            // Message ordinal held currently in slot.
+  int64_t message_size = 0;       // Size of message held in slot.
+  int32_t buffer_index = 0;       // Index of buffer.
   toolbelt::BitSet<kMaxSlotOwners> owners{}; // One bit per publisher/subscriber.
 };
 
@@ -132,14 +132,14 @@ struct BufferHeader {
 struct ChannelControlBlock {          // a.k.a CCB
   char channel_name[kMaxChannelName]{}; // So that you can see the name in a
                                       // debugger or hexdump.
-  int num_slots{};
-  int64_t next_ordinal{}; // Next ordinal to use.
-  int buffer_index{};     // Which buffer in buffers array to use.
-  int num_buffers{};      // Size of buffers array in shared memory.
+  int num_slots = 0;
+  int64_t next_ordinal = 0; // Next ordinal to use.
+  int buffer_index = 0;     // Which buffer in buffers array to use.
+  int num_buffers = 0;      // Size of buffers array in shared memory.
 
   // Statistics counters.
-  int64_t total_bytes{};
-  int64_t total_messages{};
+  int64_t total_bytes = 0;
+  int64_t total_messages = 0;
 
   // Slot lists.
   // Active list: slots with active messages in them.

--- a/common/channel.h
+++ b/common/channel.h
@@ -94,26 +94,26 @@ struct SystemControlBlock {
 // addresses in each client.  Instead they use an offset from the
 // start of the ChannelControlBlock (CCB) as a pointer.
 struct SlotListElement {
-  int32_t prev;
-  int32_t next;
+  int32_t prev{};
+  int32_t next{};
 };
 
 // Double linked list header in shared memory.
 struct SlotList {
-  int32_t first;
-  int32_t last;
+  int32_t first{};
+  int32_t last{};
 };
 
 // This is the meta data for a slot.  It is always in a linked list.
 struct MessageSlot {
-  SlotListElement element;
-  int32_t id;                 // Unique ID for slot (0...num_slots-1).
-  int16_t ref_count;          // Number of subscribers referring to this slot.
-  int16_t reliable_ref_count; // Number of reliable subscriber references.
-  int64_t ordinal;            // Message ordinal held currently in slot.
-  int64_t message_size;       // Size of message held in slot.
-  int32_t buffer_index;       // Index of buffer.
-  toolbelt::BitSet<kMaxSlotOwners> owners; // One bit per publisher/subscriber.
+  SlotListElement element{};
+  int32_t id{};                 // Unique ID for slot (0...num_slots-1).
+  int16_t ref_count{};          // Number of subscribers referring to this slot.
+  int16_t reliable_ref_count{}; // Number of reliable subscriber references.
+  int64_t ordinal{};            // Message ordinal held currently in slot.
+  int64_t message_size{};       // Size of message held in slot.
+  int32_t buffer_index{};       // Index of buffer.
+  toolbelt::BitSet<kMaxSlotOwners> owners{}; // One bit per publisher/subscriber.
 };
 
 // This is located just before the prefix of the first slot's buffer.  It
@@ -130,29 +130,29 @@ struct BufferHeader {
 //
 // This is in shared memory so no pointers are possible.
 struct ChannelControlBlock {          // a.k.a CCB
-  char channel_name[kMaxChannelName]; // So that you can see the name in a
+  char channel_name[kMaxChannelName]{}; // So that you can see the name in a
                                       // debugger or hexdump.
-  int num_slots;
-  int64_t next_ordinal; // Next ordinal to use.
-  int buffer_index;     // Which buffer in buffers array to use.
-  int num_buffers;      // Size of buffers array in shared memory.
+  int num_slots{};
+  int64_t next_ordinal{}; // Next ordinal to use.
+  int buffer_index{};     // Which buffer in buffers array to use.
+  int num_buffers{};      // Size of buffers array in shared memory.
 
   // Statistics counters.
-  int64_t total_bytes;
-  int64_t total_messages;
+  int64_t total_bytes{};
+  int64_t total_messages{};
 
   // Slot lists.
   // Active list: slots with active messages in them.
   // Busy list: slots allocated to publishers
   // Free list: slots not allocated.
-  SlotList active_list;
-  SlotList busy_list;
-  SlotList free_list;
+  SlotList active_list{};
+  SlotList busy_list{};
+  SlotList free_list{};
 
-  pthread_mutex_t lock; // Lock for this channel only.
+  pthread_mutex_t lock{}; // Lock for this channel only.
 
   // Variable number of MessageSlot structs (num_slots long).
-  MessageSlot slots[0];
+  MessageSlot slots[0]{};
 };
 
 absl::StatusOr<SystemControlBlock *>

--- a/common/channel.h
+++ b/common/channel.h
@@ -6,15 +6,16 @@
 #ifndef __COMMON_CHANNEL_H
 #define __COMMON_CHANNEL_H
 
+#include <pthread.h>
 #include <stdio.h>
+
+#include <cstdint>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "toolbelt/bitset.h"
 #include "toolbelt/fd.h"
-#include <cstdint>
-#include <pthread.h>
-#include <string>
 
 namespace subspace {
 
@@ -38,7 +39,7 @@ static constexpr size_t kMaxMessage = 4096;
 // On the receiving end of the bridge, the padding is
 // not received and will not be written to.
 struct MessagePrefix {
-  int32_t padding; // Padding for Socket::SendMessage.
+  int32_t padding;  // Padding for Socket::SendMessage.
   int32_t message_size;
   int64_t ordinal;
   uint64_t timestamp;
@@ -46,9 +47,9 @@ struct MessagePrefix {
 };
 
 // Flag for flags field in MessagePrefix.
-constexpr int kMessageActivate = 1; // This is a reliable activation message.
-constexpr int kMessageBridged = 2;  // This message came from the bridge.
-constexpr int kMessageSeen = 4;     // Message has been seen.
+constexpr int kMessageActivate = 1;  // This is a reliable activation message.
+constexpr int kMessageBridged = 2;   // This message came from the bridge.
+constexpr int kMessageSeen = 4;      // Message has been seen.
 
 // We need a max channels number because the size of things in
 // shared memory needs to be fixed.
@@ -75,12 +76,12 @@ constexpr size_t kMaxChannelName = 64;
 // This is in shared memory, but it is only ever written by the
 // server so there is no lock required to access it in the clients.
 struct ChannelCounters {
-  uint16_t num_pub_updates;   // Number of updates to publishers.
-  uint16_t num_sub_updates;   // Number of updates to subscribers.
-  uint16_t num_pubs;          // Current number of publishers.
-  uint16_t num_reliable_pubs; // Current number of reliable publishers.
-  uint16_t num_subs;          // Current number of subscribers.
-  uint16_t num_reliable_subs; // Current number of reliable subscribers.
+  uint16_t num_pub_updates;    // Number of updates to publishers.
+  uint16_t num_sub_updates;    // Number of updates to subscribers.
+  uint16_t num_pubs;           // Current number of publishers.
+  uint16_t num_reliable_pubs;  // Current number of reliable publishers.
+  uint16_t num_subs;           // Current number of subscribers.
+  uint16_t num_reliable_subs;  // Current number of reliable subscribers.
 };
 
 struct SystemControlBlock {
@@ -94,33 +95,34 @@ struct SystemControlBlock {
 // addresses in each client.  Instead they use an offset from the
 // start of the ChannelControlBlock (CCB) as a pointer.
 struct SlotListElement {
-  int32_t prev{};
-  int32_t next{};
+  int32_t prev = 0;
+  int32_t next = 0;
 };
 
 // Double linked list header in shared memory.
 struct SlotList {
-  int32_t first{};
-  int32_t last{};
+  int32_t first = 0;
+  int32_t last = 0;
 };
 
 // This is the meta data for a slot.  It is always in a linked list.
 struct MessageSlot {
   SlotListElement element{};
-  int32_t id{};                 // Unique ID for slot (0...num_slots-1).
-  int16_t ref_count{};          // Number of subscribers referring to this slot.
-  int16_t reliable_ref_count{}; // Number of reliable subscriber references.
-  int64_t ordinal{};            // Message ordinal held currently in slot.
-  int64_t message_size{};       // Size of message held in slot.
-  int32_t buffer_index{};       // Index of buffer.
-  toolbelt::BitSet<kMaxSlotOwners> owners{}; // One bit per publisher/subscriber.
+  int32_t id = 0;         // Unique ID for slot (0...num_slots-1).
+  int16_t ref_count = 0;  // Number of subscribers referring to this slot.
+  int16_t reliable_ref_count = 0;  // Number of reliable subscriber references.
+  int64_t ordinal = 0;             // Message ordinal held currently in slot.
+  int64_t message_size = 0;        // Size of message held in slot.
+  int32_t buffer_index = 0;        // Index of buffer.
+  toolbelt::BitSet<kMaxSlotOwners>
+      owners{};  // One bit per publisher/subscriber.
 };
 
 // This is located just before the prefix of the first slot's buffer.  It
 // is 64 bits long to align the prefix to 64 bits.
 struct BufferHeader {
-  int32_t refs;    // Number of references to this buffer.
-  int32_t padding; // Align to 64 bits.
+  int32_t refs;     // Number of references to this buffer.
+  int32_t padding;  // Align to 64 bits.
 };
 
 // The control data for a channel.  This memory is
@@ -129,17 +131,17 @@ struct BufferHeader {
 // at a virtual address chosen by the OS.
 //
 // This is in shared memory so no pointers are possible.
-struct ChannelControlBlock {          // a.k.a CCB
-  char channel_name[kMaxChannelName]{}; // So that you can see the name in a
-                                      // debugger or hexdump.
-  int num_slots{};
-  int64_t next_ordinal{}; // Next ordinal to use.
-  int buffer_index{};     // Which buffer in buffers array to use.
-  int num_buffers{};      // Size of buffers array in shared memory.
+struct ChannelControlBlock {             // a.k.a CCB
+  char channel_name[kMaxChannelName]{};  // So that you can see the name in a
+                                         // debugger or hexdump.
+  int num_slots = 0;
+  int64_t next_ordinal = 0;  // Next ordinal to use.
+  int buffer_index = 0;      // Which buffer in buffers array to use.
+  int num_buffers = 0;       // Size of buffers array in shared memory.
 
   // Statistics counters.
-  int64_t total_bytes{};
-  int64_t total_messages{};
+  int64_t total_bytes = 0;
+  int64_t total_messages = 0;
 
   // Slot lists.
   // Active list: slots with active messages in them.
@@ -149,14 +151,14 @@ struct ChannelControlBlock {          // a.k.a CCB
   SlotList busy_list{};
   SlotList free_list{};
 
-  pthread_mutex_t lock{}; // Lock for this channel only.
+  pthread_mutex_t lock{};  // Lock for this channel only.
 
   // Variable number of MessageSlot structs (num_slots long).
   MessageSlot slots[0]{};
 };
 
-absl::StatusOr<SystemControlBlock *>
-CreateSystemControlBlock(toolbelt::FileDescriptor &fd);
+absl::StatusOr<SystemControlBlock *> CreateSystemControlBlock(
+    toolbelt::FileDescriptor &fd);
 
 struct SlotBuffer {
   SlotBuffer(int32_t slot_size) : slot_size(slot_size) {}
@@ -187,12 +189,13 @@ struct SharedMemoryFds {
     return *this;
   }
 
-  toolbelt::FileDescriptor ccb;    // Channel Control Block.
-  std::vector<SlotBuffer> buffers; // Message Buffers.
+  toolbelt::FileDescriptor ccb;     // Channel Control Block.
+  std::vector<SlotBuffer> buffers;  // Message Buffers.
 };
 
 // Aligned to given power of 2.
-template <int64_t alignment> int64_t Aligned(int64_t v) {
+template <int64_t alignment>
+int64_t Aligned(int64_t v) {
   return (v + (alignment - 1)) & ~(alignment - 1);
 }
 
@@ -219,7 +222,7 @@ struct BufferSet {
 // same process, each of them maps in the shared memory. No attempt
 // is made to share the Channel objects.
 class Channel {
-public:
+ public:
   struct PublishedMessage {
     MessageSlot *new_slot;
     int64_t ordinal;
@@ -237,9 +240,8 @@ public:
   // file descriptors for the allocated CCB and buffers.  The
   // SCB has already been allocated and will be mapped in for
   // this channel.  This is only used in the server.
-  absl::StatusOr<SharedMemoryFds>
-  Allocate(const toolbelt::FileDescriptor &scb_fd, int slot_size,
-           int num_slots);
+  absl::StatusOr<SharedMemoryFds> Allocate(
+      const toolbelt::FileDescriptor &scb_fd, int slot_size, int num_slots);
 
   // Client-side channel mapping.  The SharedMemoryFds contains the
   // file descriptors for the CCB and buffers.  The num_slots_
@@ -404,7 +406,7 @@ public:
 
   const std::vector<BufferSet> &GetBuffers() const { return buffers_; }
 
-private:
+ private:
   int32_t ToCCBOffset(void *addr) const {
     return (int32_t)(reinterpret_cast<char *>(addr) -
                      reinterpret_cast<char *>(ccb_));
@@ -467,7 +469,7 @@ private:
   std::string name_;
   int num_slots_;
 
-  int channel_id_; // ID allocated from server.
+  int channel_id_;  // ID allocated from server.
   std::string type_;
 
   uint16_t num_updates_ = 0;
@@ -478,5 +480,5 @@ private:
   bool debug_ = false;
 };
 
-} // namespace subspace
+}  // namespace subspace
 #endif /* __COMMON_CHANNEL_H */


### PR DESCRIPTION
Fixes for link errors and build warning:

```
bazel build //...
Starting local Bazel server and connecting to it...
INFO: Analyzed 17 targets (81 packages loaded, 3789 targets configured).
INFO: Found 17 targets...
INFO: From Compiling common/channel.cc:
common/channel.cc: In member function 'absl::lts_20211102::StatusOr<subspace::SharedMemoryFds> subspace::Channel::Allocate(const toolbelt::FileDescriptor&, int, int)':
common/channel.cc:207:27: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct subspace::ChannelControlBlock'; use assignment or value-initialization instead [-Wclass-memaccess]
  207 |   memset(ccb_, 0, ccb_size);
      |                           ^
In file included from common/channel.cc:5:
./common/channel.h:132:8: note: 'struct subspace::ChannelControlBlock' declared here
  132 | struct ChannelControlBlock {          // a.k.a CCB
      |        ^~~~~~~~~~~~~~~~~~~
ERROR: /home/maeve/subspace/client/BUILD.bazel:24:8: Linking client/client_test failed: (Exit 1): gcc failed: error executing command (from target //client:client_test) /usr/bin/gcc @bazel-out/k8-fastbuild/bin/client/client_test-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-fastbuild/bin/_solib_k8/libcommon_Slibsubspace_Ucommon.so: error: undefined reference to 'shm_open'
bazel-out/k8-fastbuild/bin/_solib_k8/libcommon_Slibsubspace_Ucommon.so: error: undefined reference to 'shm_unlink'
collect2: error: ld returned 1 exit status
INFO: Elapsed time: 34.645s, Critical Path: 5.08s
INFO: 402 processes: 126 internal, 276 linux-sandbox.
FAILED: Build did NOT complete successfully
```